### PR TITLE
[INGA] Populate `db/seeds` with inital users

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,5 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+Dir[Rails.root.join("db", "seeds", "**", "*.rb")].each { |file| require file }
+
+return unless Rails.env.development?
+
+Seeds::Users.run

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -1,0 +1,31 @@
+module Seeds
+  class Users
+    class << self
+      def run
+        ActiveRecord::Base.connection.truncate_tables('users', 'user_roles')
+        seed_users
+      end
+
+      private
+
+      def seed_users
+        puts "Seeding users..."
+        ActiveRecord::Base.transaction do
+          admin = User.create!(username: "admin", password: "a")
+          super_user = User.create!(username: "super", password: "a")
+          logger = User.create!(username: "logger", password: "a")
+          analyst = User.create!(username: "analyst", password: "a")
+
+          set_roles(admin, :admin)
+          set_roles(logger, :logger)
+          set_roles(analyst, :analyst)
+          set_roles(super_user, :admin, :logger, :analyst)
+        end
+      end
+
+      def set_roles(user, *roles)
+        roles.each { |role| UserRole.create!(user: user, role: role) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## TL;DR
Populates inital seeds

---

## What is this PR trying to achieve?
`db:seed` will now prepopulate data. This will create 4 users: `admin`, `logger`, `analsyt`, `super`.

---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
