### PR TITLE
Make subproject components render as links

### DIFF
--- a/app/components/home/projects_card_component.html.erb
+++ b/app/components/home/projects_card_component.html.erb
@@ -9,7 +9,7 @@
               <%= render BadgeComponent.new(text: subproject_text(project), colour: :success, style: :soft) %>
             </div>
           </div>
-          <div class="flex flex-col gap-2">
+          <div class="flex flex-col">
             <p class="text-base-content/70 font-medium text-xs mb-1"> Subprojects </p>
             <% project.subprojects.each do |subproject| %>
               <%= render Home::SubprojectCardComponent.new(subproject: subproject) %>

--- a/app/components/home/subproject_card_component.html.erb
+++ b/app/components/home/subproject_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="w-full flex items-center justify-between gap-3">
+<%= link_to subproject_path, class: "w-full flex items-center justify-between hover:bg-base-300 p-2 rounded-md" do %>
   <div class="flex items-center gap-3 min-w-0">
     <div class="w-8 h-8 rounded-full border border-base-300 flex items-center justify-center shrink-0">
       <%= render IconComponent.new(icon: "tree-fill", classes: "text-gray-11") %>
@@ -12,13 +12,4 @@
       </p>
     </div>
   </div>
-
-  <div class="flex items-center gap-2 shrink-0">
-    <button class="btn btn-circle w-8 h-8">
-      <%= render IconComponent.new(icon: "gear") %>
-    </button>
-    <button class="btn btn-circle w-8 h-8">
-      <%= render IconComponent.new(icon: "vector-pen") %>
-    </button>
-  </div>
-</div>
+<% end %>

--- a/app/components/home/subproject_card_component.rb
+++ b/app/components/home/subproject_card_component.rb
@@ -6,5 +6,7 @@ module Home
       super()
       @subproject = subproject
     end
+
+    def subproject_path = project_subproject_path(@subproject.project, @subproject)
   end
 end


### PR DESCRIPTION
## TL;DR

Change subproject_card_component to render as a link.

Before:
<img width="1482" height="649" alt="image" src="https://github.com/user-attachments/assets/c8315266-4d2b-4398-9890-6340cabb6e22" />
After:
<img width="1827" height="661" alt="image" src="https://github.com/user-attachments/assets/ef3c53cd-f22c-4c99-9e48-bb53db74618c" />

---

## What is this PR trying to achieve?
It removes repetitive icons and simplifies the UI.

---

## How did you achieve it?
It is just CSS.

---

## Checklist
- [ ] Changes have been top-hatted locally
- [ ] Tests have been added or updated
- [ ] Documentation has been updated (if applicable)
- [ ] Linked related issues
