### PR TITLE
fix: correct class name for textarea form helper

### DIFF
--- a/app/builders/default_form_builder.rb
+++ b/app/builders/default_form_builder.rb
@@ -6,7 +6,7 @@ class DefaultFormBuilder < ActionView::Helpers::FormBuilder
     password_field: "input",
     phone_field: "input",
     search_field: "input",
-    textarea: "input",
+    textarea: "textarea",
     text_field: "input"
   }.freeze
 


### PR DESCRIPTION
## TL;DR

The class for the `textarea` form helper was updated from `"input"` to the correct class `"textarea"`.

---

## What is this PR trying to achieve?

Fix incorrect `textarea` form helper class.

---

## How did you achieve it?

I replaced `"input"` with `"textarea"`

---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
