### PR TITLE
fix: replace string interpolation with hashes to prevent tailwind purging

### DIFF
--- a/app/components/badge_component.rb
+++ b/app/components/badge_component.rb
@@ -5,6 +5,35 @@ class BadgeComponent < ViewComponent::Base
   SIZES = %i[xs sm md lg xl].freeze
   STYLES = %i[solid soft outline dash ghost].freeze
 
+  COLOUR_CLASSES = {
+    neutral: "badge-neutral",
+    primary: "badge-primary",
+    secondary: "badge-secondary",
+    accent: "badge-accent",
+    info: "badge-info",
+    success: "badge-success",
+    warning: "badge-warning",
+    error: "badge-error"
+  }.freeze
+
+  SIZE_CLASSES = {
+    xs: "badge-xs",
+    sm: "badge-sm",
+    md: "badge-md",
+    lg: "badge-lg",
+    xl: "badge-xl"
+  }.freeze
+
+  STYLE_CLASSES = {
+    solid: nil,
+    soft: "badge-soft",
+    outline: "badge-outline",
+    dash: "badge-dash",
+    ghost: "badge-ghost"
+  }.freeze
+
+  private_constant :COLOUR_CLASSES, :SIZE_CLASSES, :STYLE_CLASSES
+
   def initialize(text:, colour: :neutral, size: :md, style: :solid)
     super()
 
@@ -22,19 +51,11 @@ class BadgeComponent < ViewComponent::Base
   private
 
   def css_classes
-    classes = ["px-2 badge", "badge-#{@size}"]
-    case @style
-    when :solid
-      classes << "badge-#{@colour}"
-    when :soft
-      classes << "badge-soft" << "badge-#{@colour}"
-    when :outline
-      classes << "badge-outline" << "badge-#{@colour}"
-    when :dash
-      classes << "badge-dash" << "badge-#{@colour}"
-    when :ghost
-      classes << "badge-ghost"
-    end
-    classes.join(" ")
+    class_names(
+      "px-2 badge",
+      SIZE_CLASSES[@size],
+      STYLE_CLASSES[@style],
+      (COLOUR_CLASSES[@colour] unless @style == :ghost)
+    )
   end
 end


### PR DESCRIPTION
## TL;DR

- Fixes a bug where badge colors and sizes would not apply to `BadgeComponent`s.
- This is done by explicitly defining badge color and size classes in hashes. This ensures the TailwindCSS detects and includes them in the build. 

---

## What is this PR trying to achieve?

Fixes a bug where badge colors and sizes would not apply to `BadgeComponent`s.

---

## How did you achieve it?

Replaced string interpolation with hashes so the full string literals can be detected by TailwindCSS.

---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
