### PR TITLE
feat: override default light theme colors to better match the designs

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -8,7 +8,32 @@
 
 /* Optional for custom themes – Docs: https://daisyui.com/docs/themes/#how-to-add-a-new-custom-theme */
 @plugin "./daisyui-theme.mjs" {
-  /* custom theme here */
+  name: "light";
+  default: true;
+
+  --color-primary: oklch(54% 0.18 149);
+  --color-primary-content: oklch(98% 0 0);
+
+  --color-secondary: oklch(46% 0.098 169);
+  --color-secondary-content: oklch(98% 0 0);
+
+  --color-accent:oklch(58% 0.12 185);
+  --color-accent-content: oklch(98% 0 0);
+
+  --color-neutral: oklch(15% 0.038 174);
+  --color-accent-content: oklch(98% 0 0);
+
+  --color-info: oklch(73% 0.16 236);
+  --color-info-content: oklch(30% 0.065 243);
+  
+  --color-success: oklch(72% 0.15 159);
+  --color-success-content: oklch(28% 0.074 169);
+
+  --color-warning: oklch(84% 0.17 84);
+  --color-warning-content: oklch(43% 0.11 46);
+
+  --color-error: oklch(69% 0.19 22);
+  --color-error-content: oklch(28% 0.11 12)
 }
 
 @keyframes fade-in-out {


### PR DESCRIPTION
## TL;DR

Override default DaisyUI light theme colors to better match the designs and the forest theme.

<img width="1538" height="240" alt="image" src="https://github.com/user-attachments/assets/89354ee2-795f-421c-b841-19545e58e9ed" />

---

## What is this PR trying to achieve?

Change the theme colors using DaisyUI's theme overriding feature instead of hardcoding the colors into each design

---

## How did you achieve it?

Overrode semantic color classes according to [the DaisyUI docs](https://daisyui.com/docs/themes/#how-to-add-a-new-custom-theme).

---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
