### PR TITLE
feat: modal for edit user

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,11 @@ class UsersController < ApplicationController
 
   def edit
     @user = User.find(params[:id])
+
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
   end
 
   def create

--- a/app/views/users/edit.turbo_stream.erb
+++ b/app/views/users/edit.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "modal" do %>
+  <%= render ModalComponent.new(title: "Edit User") do %>
+    <%= render Users::FormComponent.new(user: @user) %>
+  <% end %>
+<% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -21,7 +21,7 @@
         <% end %>
         <% table.column :actions, header: "" do |user| %>
           <div class="flex gap-2">
-            <%= link_to "Edit", edit_user_path(user), class: "btn btn-xs btn-outline btn-info" %>
+            <%= link_to "Edit", edit_user_path(user), data: { turbo_stream: true }, class: "btn btn-xs btn-outline btn-info" %>
             <%= button_to "Delete", user_path(user), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-xs btn-outline btn-error" %>
           </div>
         <% end %>

--- a/config/locales/users.en.yml
+++ b/config/locales/users.en.yml
@@ -11,14 +11,15 @@ en:
     destroy:
       success: "Account deleted successfully."
       self_deletion: "You cannot delete your own account."
+    index:
+      create_user_button: "Create User"
+    form:
+      confirm_password: "Confirm password"
+      placeholder: "Type here"
   role_badge_component:
     roles:
       admin: "Admin"
       reporter: "Reporter"
       analyst: "Analyst"
       fallback: "Unknown"
-  form:
-    confirm_password: "Confirm password"
-    placeholder: "Type here"
-  index:
-    create_user_button: "Create User"
+  


### PR DESCRIPTION
## TL;DR
Implements a modal for editing users

---

## What is this PR trying to achieve?
-closes #120 

---

## How did you achieve it?
- Changed edit button on the user index page to make a modal pop up when editing
<img width="786" height="744" alt="image" src="https://github.com/user-attachments/assets/f7ffab8a-1150-4bee-a692-64fe5e4975b2" />


---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
