### PR TITLE
feat: seed log entries with test data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,3 +4,4 @@ return unless Rails.env.development?
 
 Seeds::Users.run
 Seeds::Projects.run
+Seeds::LogEntries.run

--- a/db/seeds/log_entries.rb
+++ b/db/seeds/log_entries.rb
@@ -1,0 +1,42 @@
+module Seeds
+  class LogEntries
+    class << self
+      def run
+        ActiveRecord::Base.connection.truncate_tables("log_entries")
+        seed_log_entries
+      end
+
+      private
+
+      def seed_log_entries
+        puts "Seeding log entries..."
+
+        user = User.first
+        subprojects = Subproject.all
+
+        if user.nil? || subprojects.empty?
+          puts "Skipping log entries: No users or subprojects found."
+          return
+        end
+
+        logs = []
+        verified_values = [false, true]
+
+        subprojects.cycle(2) do |subproject|
+          logs << {
+            user_id: user.id,
+            subproject_id: subproject.id,
+            created_at: Faker::Time.between(from: 30.days.ago, to: Time.current),
+            metadata: {
+              "metric_value" => rand(10.0..100.0).round(2),
+              "verified" => verified_values.sample,
+              "notes" => Faker::Lorem.sentence(word_count: 8)
+            }
+          }
+        end
+
+        LogEntry.insert_all(logs) # rubocop:disable Rails/SkipsModelValidations
+      end
+    end
+  end
+end


### PR DESCRIPTION
## TL;DR

- Seed log entries with test data: add two log entries per subproject, all belonging to one user

---

## What is this PR trying to achieve?

- Allows the application to be tested more easily

---

## How did you achieve it?

- Added two log entries per subproject: one with `verified => true` and one with `verified => false`.
- Used `rand` and `Faker` to generate data.

---

## Checklist
- [x] Changes have been top-hatted locally
- [x] Tests have been added or updated
- [x] Documentation has been updated (if applicable)
- [x] Linked related issues
