### PR TITLE
[SIDEBAR] Added a mobile friendly dock component

### DIFF
--- a/app/components/dock_component.html.erb
+++ b/app/components/dock_component.html.erb
@@ -1,0 +1,14 @@
+<div class="dock">
+  <% items.each do |item| %>
+    <%= link_to item.path,
+                class: wrapper_classes do %>
+        <%= render IconComponent.new(icon: item.icon, size: :md,
+                                     classes: icon_classes) %>
+      <span class="dock-label text-center"><%= item.name %></span>
+    <% end %>
+  <% end %>
+  <%= button_to logout_item.path, method: :delete, class: wrapper_classes do %>
+    <%= render IconComponent.new(icon: logout_item.icon, size: :md, classes: icon_classes) %>
+    <span class="dock-label text-center"> <%= logout_item.name %> </span>
+  <% end %>
+</div>

--- a/app/components/dock_component.rb
+++ b/app/components/dock_component.rb
@@ -1,0 +1,14 @@
+class DockComponent < ViewComponent::Base
+  attr_reader :items, :logout_item
+
+  def initialize(items:, logout_item:)
+    super()
+    @items = items
+    @logout_item = logout_item
+  end
+
+  private
+
+  def wrapper_classes = "group flex flex-col items-center justify-center gap-1"
+  def icon_classes =  "transition-transform duration-150 group-hover:-translate-y-1"
+end

--- a/app/components/sidebar_component.html.erb
+++ b/app/components/sidebar_component.html.erb
@@ -1,3 +1,4 @@
+<div class="hidden sm:block">
 <ul class="menu shadow-lg bg-base-200 w-64 min-h-screen tracking-wide justify-between">
   <div>
     <div class="px-4 py-4 border-b border-base-300">
@@ -27,10 +28,14 @@
   </div>
   <div class="border-t border-base-300 py-2">
     <li>
-      <%= button_to logout_path, method: :delete, class: "flex gap-3" do %>
-        <%= render IconComponent.new(icon: "box-arrow-left", size: :md, classes: "w-5 h-5") %>
-        <span>Logout</span>
+      <%= button_to logout_item.path, method: :delete, class: "flex gap-3" do %>
+        <%= render IconComponent.new(icon: logout_item.icon, size: :md, classes: "w-5 h-5") %>
+        <span> <%= logout_item.name %> </span>
       <% end %>
     </li>
   </div>
 </ul>
+</div>
+<div class="sm:hidden">
+  <%= render DockComponent.new(items: sections.first.items, logout_item: logout_item) %>
+</div>

--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -40,5 +40,9 @@ class SidebarComponent < ViewComponent::Base
     )
   end
 
+  def logout_item
+    @logout_item ||= SIDEBAR_ITEM.new(name: "Logout", path: ROUTES.logout_path, icon: "box-arrow-left")
+  end
+
   def render? = !current_page?(ROUTES.login_path)
 end


### PR DESCRIPTION
## TL;DR
Briefly describe what this PR does and why it is needed. Include any relevant background or context.
Added a mobile friendly dock component, to be shown on small screens.

- Relates to: #219

<img width="446" height="896" alt="image" src="https://github.com/user-attachments/assets/876e9e80-55a3-40d4-8100-ffd53d4df1c6" />
---

## Checklist
- [ ] Changes have been top-hatted locally
- [ ] Tests have been added or updated
- [ ] Documentation has been updated (if applicable)
- [ ] Linked related issues
