### PR TITLE
[Seeds] Journal Seeds Now Render Markdown_Content as HTML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
+  gem "redcarpet"
   gem "web-console"
 
   gem "i18n-tasks", "~> 1.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
@@ -476,6 +477,7 @@ DEPENDENCIES
   propshaft
   puma (>= 5.0)
   rails (~> 8.1.0)
+  redcarpet
   rubocop (~> 1.81, >= 1.81.1)
   rubocop-capybara (~> 2.22, >= 2.22.1)
   rubocop-factory_bot (~> 2.27, >= 2.27.1)

--- a/db/seeds/journals.rb
+++ b/db/seeds/journals.rb
@@ -1,3 +1,5 @@
+require "redcarpet"
+
 module Seeds
   class Journals
     class << self
@@ -12,12 +14,15 @@ module Seeds
         puts "Seeding journals..."
         return if user.nil? || subprojects.empty?
 
+        renderer = Redcarpet::Render::HTML.new(prettify: true)
+        markdown = Redcarpet::Markdown.new(renderer)
+
         subprojects.cycle(2) do |subproject|
           Journal.create!(
             user: user,
             subproject: subproject,
             title: Faker::Lorem.sentence,
-            markdown_content: Faker::Markdown.sandwich(sentences: 6, repeat: 3)
+            markdown_content: markdown.render(Faker::Markdown.sandwich(sentences: 6, repeat: 3))
           )
         end
       end


### PR DESCRIPTION
## TL;DR
Briefly describe what this PR does and why it is needed. Include any relevant background or context.

Correctly uses `has_rich_text`, and complies the produced markdown content

<img width="1326" height="491" alt="image" src="https://github.com/user-attachments/assets/e2ebb0ef-a72f-4d1f-b0a3-4e566fbc8446" />

---

## Checklist
- [ ] Changes have been top-hatted locally
- [ ] Tests have been added or updated
- [ ] Documentation has been updated (if applicable)
- [ ] Linked related issues
